### PR TITLE
Feat: project step 2

### DIFF
--- a/src/main/java/com/parkit/parkingsystem/service/FareCalculatorService.java
+++ b/src/main/java/com/parkit/parkingsystem/service/FareCalculatorService.java
@@ -10,11 +10,11 @@ public class FareCalculatorService {
             throw new IllegalArgumentException("Out time provided is incorrect:"+ticket.getOutTime().toString());
         }
 
-        int inHour = ticket.getInTime().getHours();
-        int outHour = ticket.getOutTime().getHours();
+        long inHour = ticket.getInTime().getTime();
+        long outHour = ticket.getOutTime().getTime();
 
         //TODO: Some tests are failing here. Need to check if this logic is correct
-        int duration = outHour - inHour;
+        double duration = (outHour - inHour) /(60.0*60.0*1000.0);
 
         switch (ticket.getParkingSpot().getParkingType()){
             case CAR: {


### PR DESCRIPTION
Feat: Modified "calculateFare(ticket)" tests by :
- Using getTime() to get the time in milliseconds, which corrects the bug when parking durations are not whole hours.
- Storing the duration variable as a double and dividing by 60.0 to prevent integer division from returning 0 for durations shorter than 1 hour.