### PR TITLE
Code Cleanup - Step 2 : Refactor and improve

### DIFF
--- a/src/main/java/com/parkit/parkingsystem/service/FareCalculatorService.java
+++ b/src/main/java/com/parkit/parkingsystem/service/FareCalculatorService.java
@@ -13,22 +13,22 @@ public class FareCalculatorService {
         long inHour = ticket.getInTime().getTime();
         long outHour = ticket.getOutTime().getTime();
 
-        //TODO: Some tests are failing here. Need to check if this logic is correct
-        double duration = (outHour - inHour) /(60.0*60.0*1000.0);
+        //Passage de millisecondes à heures
+        float durationInHours = (outHour - inHour) /3600000f;
 
         // Si la durée est inférieure à 30 minutes, le prix doit être égal à 0
-        if (duration < 0.5) {
+        if (durationInHours < 0.5) {
             ticket.setPrice(0);
             return; // On quitte la méthode, pas d'autre calcul à effectuer
         }
 
         switch (ticket.getParkingSpot().getParkingType()){
             case CAR: {
-                ticket.setPrice(duration * Fare.CAR_RATE_PER_HOUR);
+                ticket.setPrice(durationInHours * Fare.CAR_RATE_PER_HOUR);
                 break;
             }
             case BIKE: {
-                ticket.setPrice(duration * Fare.BIKE_RATE_PER_HOUR);
+                ticket.setPrice(durationInHours * Fare.BIKE_RATE_PER_HOUR);
                 break;
             }
             default: throw new IllegalArgumentException("Unkown Parking Type");


### PR DESCRIPTION
by :
-- Avoid unnecessary calculation in the numerator to save computation time and reduce CPU usage (3600000f = 60.0*60.0*1000.0) 
-- Switch from double to float to save memory.
-- Rename the variable from 'duration' to 'durationInHours' for better clarity and to indicate that it represents the duration in hours.